### PR TITLE
Fix code scanning alert no. 1: Incomplete URL substring sanitization

### DIFF
--- a/fapello_downloader/app/core.py
+++ b/fapello_downloader/app/core.py
@@ -5,7 +5,7 @@ from multiprocessing import Queue as multiprocessing_Queue
 from threading import Thread
 from time import sleep
 from tkinter import StringVar
-
+from urllib.parse import urlparse
 from fapello_downloader.app.gui.base import GUI
 from fapello_downloader.consts import DownloadStatus
 from fapello_downloader.requests_handler import (download_orchestrator,
@@ -64,7 +64,7 @@ class App:
         elif selected_link == "":
             self.info_message.set("Insert a valid Fapello.com link")
 
-        elif "https://fapello.com" in selected_link:
+        elif urlparse(selected_link).hostname == "fapello.com":
             download_type = "fapello.com"
 
             if not selected_link.endswith("/"):


### PR DESCRIPTION
Fixes [https://github.com/YisusChrist/Fapello.Downloader/security/code-scanning/1](https://github.com/YisusChrist/Fapello.Downloader/security/code-scanning/1)

To fix the problem, we need to parse the URL and validate its hostname to ensure it matches the expected domain. This can be done using Python's `urllib.parse` module. Specifically, we will:
1. Parse the URL using `urlparse`.
2. Extract the hostname from the parsed URL.
3. Check if the hostname matches the expected domain (`fapello.com`).

This approach ensures that the URL is correctly validated and prevents malicious URLs from bypassing the check.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
